### PR TITLE
Loadout Manager changes for the Chaos Wastes update.

### DIFF
--- a/itemV2.cfg
+++ b/itemV2.cfg
@@ -8,8 +8,9 @@ Some things that might not be obvious:
 [*] Loadouts are saved to a Steam cloud file, so if you play Vermintide 2 on multiple PCs using the same account, your loadouts should be automatically kept up to date on all of them without having to manually copy files.
 [/list]
 
-Version: 1.1.3
+Version: 1.1.4
 Changelist:
+1.1.4: Fix breakage caused by Chaos Wastes update, and allow up to 30 loadouts to be saved per career.
 1.1.3: Fix to allow equipping a melee weapon in the ranged slot for Grail Knight.
 1.1.2: Fix for loadouts with Throwing Axes not working.
 1.1.1: Fixes for breakage from changes in v2.0 of the game.


### PR DESCRIPTION
- Store separate loadouts for Chaos Wastes mode.
- Bot overrides should now work in Chaos Wastes.
- Allow up to 30 loadouts to be saved for each career.